### PR TITLE
Changed foreach_policy to foreach_trainable_policy

### DIFF
--- a/rllib/agents/dqn/dqn.py
+++ b/rllib/agents/dqn/dqn.py
@@ -275,7 +275,7 @@ def collect_metrics(trainer):
 
 
 def disable_exploration(trainer):
-    trainer.evaluation_workers.local_worker().foreach_policy(
+    trainer.evaluation_workers.local_worker().foreach_trainable_policy(
         lambda p, _: p.set_epsilon(0))
 
 


### PR DESCRIPTION
Changed foreach_policy to foreach_trainable_policy in DQN when disabling exploration. This makes it consistent with the rest of the file

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
Previously, it crashes when you have a non-trainable policy that doesn't implement set_epsilon.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
